### PR TITLE
Removing duplicates imports from an Xcode target

### DIFF
--- a/XCodeTarget.rb
+++ b/XCodeTarget.rb
@@ -45,4 +45,9 @@ class XCodeTarget
     imports = all_unique_imports.map { |import| import.split.last }
     dependency_list - imports
   end
+
+  # Removes all the duplicate import statements from all the files linked to the target
+  def remove_duplicate_imports
+    files.each(&:remove_duplicate_imports)
+  end
 end

--- a/duplicate_imports.rb
+++ b/duplicate_imports.rb
@@ -48,7 +48,7 @@ end
 
 def delete_duplicate_imports(project_path)
   project = XCodeProject.new(project_path)
-  project.all_targets.each { |target| target.files.each(&:remove_duplicate_imports) }
+  project.all_targets.each(&:remove_duplicate_imports)
 end
 
 if ARGV.length == 1


### PR DESCRIPTION
Adding support for removing duplicates from all the files present/linked to an Xcode target.